### PR TITLE
Added check if 'PP_CONFIG_PATH' constant is already defined

### DIFF
--- a/Service/BridgeService.php
+++ b/Service/BridgeService.php
@@ -5,8 +5,9 @@ namespace KMJ\PayPalBridgeBundle\Service;
 use PayPal\Auth\OAuthTokenCredential;
 use PayPal\Rest\ApiContext;
 
-
-define('PP_CONFIG_PATH', sys_get_temp_dir());
+if (!defined('PP_CONFIG_PATH')) {
+    define('PP_CONFIG_PATH', sys_get_temp_dir());
+}
 
 /**
  * Class BridgeService


### PR DESCRIPTION
Since sometimes (sub-requests, testing) this service maybe loaded multiple times, it should be checked if the constant was already defined, otherwise it bites your arse ;)
