### PR TITLE
composer.json should allow all versions of PayPal SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "paypal/rest-api-sdk-php": "dev-master"
+        "paypal/rest-api-sdk-php": "*"
     },
     "require-dev": {
         "symfony/framework-bundle": ">=2.0"


### PR DESCRIPTION
We want to use a certain tagged version of PayPal SDK, which is not possible with the current version constraint. It should be allowed to use any version of the PayPal SDK.
